### PR TITLE
Fix vCard export issues in WhatsApp chat extraction

### DIFF
--- a/SPIZAPiXWEB.js
+++ b/SPIZAPiXWEB.js
@@ -463,7 +463,7 @@ window.ZAPiX._internal_getallchats = async function (){
 			else if (msgType=='vcard'){
 				try{
 					mimetypeFileExtension = window.ZAPiX._fileExtensions['text/x-vcard'];
-					addFile2Zip('Attachment '+msgHelper.getId(msgs[m])+'.embedded'+mimetypeFileExtension, [msgHelper.getBody(msgs[m]),{ level:9}]);
+					addFile2Zip('Attachment '+msgHelper.getId(msgs[m])+'.embedded'+mimetypeFileExtension, [fflate.strToU8(msgHelper.getBody(msgs[m])),{ level:9}]);
 					console.log("Vcard Saved ");
 				}catch(e){
 					console.log("Vcard NOT saved - "+e.message);
@@ -528,7 +528,7 @@ window.ZAPiX._internal_getchat = async function (chatName){
 			else if (msgType=='vcard'){
 				try{
 					mimetypeFileExtension = window.ZAPiX._fileExtensions['text/x-vcard'];
-					addFile2Zip('Attachment '+msgHelper.getId(msgs[m])+'.embedded'+mimetypeFileExtension, msgHelper.getBody(msgs[m]));
+					addFile2Zip('Attachment '+msgHelper.getId(msgs[m])+'.embedded'+mimetypeFileExtension, [fflate.strToU8(msgHelper.getBody(msgs[m])),{ level:9}]);
 					console.log("Vcard Saved ");
 				}catch(e){
 					console.log("Vcard NOT saved - "+e.message);


### PR DESCRIPTION
### Summary
This pull request resolves issues with exporting WhatsApp chats containing vCard attachments in both single and full chat takeout processes.

---

### Problem
1. **Single Chat Takeout**  
   - Fails with error: `Maximum call stack size exceeded` when a chat includes vCard attachments.  
2. **Full Chat Takeout**  
   - Completes but produces unreadable `.vcf` files in the ZIP.  
   - Unit testing revealed the problem: `fflate` likely expects a `Uint8Array` but was receiving strings directly.

---

### Solution
- **_internal_getchat**:  
  - Updated the `addFile2Zip` call to convert vCard body strings to `Uint8Array` using `fflate.strToU8`.  
  - Wrapped the `Uint8Array` and compression options in an array to meet `addFile2Zip` requirements.
  ```javascript
  addFile2Zip('Attachment '+msgHelper.getId(msgs[m])+'.embedded'+mimetypeFileExtension, [fflate.strToU8(msgHelper.getBody(msgs[m])), { level: 9 }]);
- **_internal_getallchats**:
  - Ensured all string-to-Uint8Array conversions are applied consistently for vCard attachments via `fflate.strToU8`.